### PR TITLE
Add HTTP bridge for MCP server

### DIFF
--- a/server-http.js
+++ b/server-http.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const { spawn } = require('child_process');
+
+const app = express();
+const PORT = 9002;
+
+app.use(express.json());
+
+app.post('/mcp', (req, res) => {
+  const child = spawn(process.execPath, ['build/index.js'], {
+    stdio: ['pipe', 'pipe', 'inherit'],
+  });
+
+  let responseBuffer = '';
+
+  child.stdout.on('data', (chunk) => {
+    responseBuffer += chunk.toString();
+  });
+
+  child.on('error', (error) => {
+    res.status(500).send(error.message);
+  });
+
+  child.on('close', () => {
+    res.type('application/json').send(responseBuffer);
+  });
+
+  let payload = JSON.stringify(req.body ?? {});
+  if (!payload.endsWith('\n')) {
+    payload += '\n';
+  }
+  child.stdin.end(payload);
+});
+
+app.listen(PORT, () => {
+  console.log(`MCP HTTP bridge listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add an Express-based HTTP server for POST /mcp that forwards requests to the MCP process
- ensure each request spawns build/index.js, sends JSON payload, and returns the collected stdout response

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c933679ec0832f83d2150b87b0c234